### PR TITLE
fix: use empty string as default memo

### DIFF
--- a/libs/ledger-live-common/src/families/osmosis/js-signOperation.ts
+++ b/libs/ledger-live-common/src/families/osmosis/js-signOperation.ts
@@ -99,7 +99,7 @@ const signOperation = ({
         const accountId = account.id;
 
         const fee = transaction.fees || new BigNumber(DEFAULT_FEES);
-        const extra = { memo: transaction.memo || {} };
+        const extra = { memo: transaction.memo || "" };
         const type: OperationType =
           transaction.mode === "undelegate"
             ? "UNDELEGATE"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

LLM crashes when trying to render an empty object in the memo field of an optimistic operation - this was noticed when doing a send transaction. By using an empty string we won't run into this issue.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->


https://user-images.githubusercontent.com/8867651/183700894-690e0731-9a2d-4b93-b6f4-97c94149dd36.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
