### PR TITLE
feat: refactor CosmosEditMemo and add it in Osmosis LLM

### DIFF
--- a/apps/ledger-live-mobile/src/const/navigation.js
+++ b/apps/ledger-live-mobile/src/const/navigation.js
@@ -164,7 +164,7 @@ export const ScreenName = {
   VoteValidationError: "VoteValidationError",
   VoteValidationSuccess: "VoteValidationSuccess",
 
-  CosmosEditMemo: "CosmosEditMemo",
+  CosmosFamilyEditMemo: "CosmosFamilyEditMemo",
   CosmosDelegationStarted: "CosmosDelegationStarted",
   CosmosDelegationValidator: "CosmosDelegationValidator",
   CosmosDelegationValidatorSelect: "CosmosDelegationValidatorSelect",

--- a/apps/ledger-live-mobile/src/families/cosmos/EditMemo.js
+++ b/apps/ledger-live-mobile/src/families/cosmos/EditMemo.js
@@ -5,7 +5,8 @@ import SafeAreaView from "react-native-safe-area-view";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import type { Account } from "@ledgerhq/types-live";
-import type { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
+import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
+import type { Transaction as OsmosisTransaction } from "@ledgerhq/live-common/families/osmosis/types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { useTheme } from "@react-navigation/native";
 import KeyboardView from "../../components/KeyboardView";
@@ -22,14 +23,15 @@ type Props = {
 
 type RouteParams = {
   account: Account,
-  transaction: Transaction,
+  transaction: CosmosTransaction | OsmosisTransaction,
 };
 
-function CosmosEditMemo({ navigation, route }: Props) {
+function CosmosFamilyEditMemo({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const [memo, setMemo] = useState(route.params.transaction.memo);
   const account = route.params.account;
+  const currencyName = account.currency.name;
 
   const onValidateText = useCallback(() => {
     const bridge = getAccountBridge(account);
@@ -64,7 +66,7 @@ function CosmosEditMemo({ navigation, route }: Props) {
 
           <View style={styles.flex}>
             <Button
-              event="CosmosEditMemoContinue"
+              event={`${currencyName}EditMemoContinue`}
               type="primary"
               title={t("send.summary.validateMemo")}
               onPress={onValidateText}
@@ -82,7 +84,7 @@ const options = {
   headerLeft: null,
 };
 
-export { CosmosEditMemo as component, options };
+export { CosmosFamilyEditMemo as component, options };
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/ledger-live-mobile/src/families/cosmos/index.js
+++ b/apps/ledger-live-mobile/src/families/cosmos/index.js
@@ -3,12 +3,12 @@ import * as CosmosDelegationFlow from "./DelegationFlow";
 import * as CosmosRedelegationFlow from "./RedelegationFlow";
 import * as CosmosUndelegationFlow from "./UndelegationFlow";
 import * as CosmosClaimRewardsFlow from "./ClaimRewardsFlow";
-import * as CosmosEditMemo from "./EditMemo";
+import * as CosmosFamilyEditMemo from "./EditMemo";
 
 export {
   CosmosDelegationFlow,
   CosmosRedelegationFlow,
   CosmosUndelegationFlow,
   CosmosClaimRewardsFlow,
-  CosmosEditMemo,
+  CosmosFamilyEditMemo,
 };

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/CosmosFamilySendRowsCustomComponent.js
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/CosmosFamilySendRowsCustomComponent.js
@@ -1,0 +1,71 @@
+// @flow
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "@react-navigation/native";
+import type { Account } from "@ledgerhq/types-live";
+import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
+import type { Transaction as OsmosisTransaction } from "@ledgerhq/live-common/families/osmosis/types";
+import LText from "../../../components/LText";
+import SummaryRow from "../../../screens/SendFunds/SummaryRow";
+
+type Props = {
+  transaction: CosmosTransaction | OsmosisTransaction,
+  editMemo: () => void,
+};
+
+export default function CosmosFamilySendRowsCustomComponent({
+  transaction,
+  editMemo,
+}: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  return (
+    <View>
+      <SummaryRow title={t("send.summary.memo.title")} onPress={editMemo}>
+        {transaction.memo ? (
+          <LText
+            semiBold
+            style={styles.tagText}
+            onPress={editMemo}
+            numberOfLines={1}
+          >
+            {transaction.memo}
+          </LText>
+        ) : (
+          <LText
+            style={[
+              styles.link,
+              {
+                textDecorationColor: colors.live,
+              },
+            ]}
+            color="live"
+            onPress={editMemo}
+          >
+            {t("common.edit")}
+          </LText>
+        )}
+      </SummaryRow>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  memoContainer: {
+    flexDirection: "row",
+  },
+  tagText: {
+    flex: 1,
+    fontSize: 14,
+    textAlign: "right",
+  },
+  link: {
+    textDecorationStyle: "solid",
+    textDecorationLine: "underline",
+    marginLeft: 8,
+  },
+  memo: {
+    marginBottom: 10,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/osmosis/SendRowsCustom.js
+++ b/apps/ledger-live-mobile/src/families/osmosis/SendRowsCustom.js
@@ -2,16 +2,16 @@
 import React, { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { Account } from "@ledgerhq/types-live";
-import type { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
+import type { Transaction } from "@ledgerhq/live-common/families/osmosis/types";
 import { ScreenName } from "../../const";
-import CosmosFamilySendRowsCustomComponent from "./shared/CosmosFamilySendRowsCustomComponent";
+import CosmosFamilySendRowsCustomComponent from "../cosmos/shared/CosmosFamilySendRowsCustomComponent";
 
 type Props = {
   account: Account,
   transaction: Transaction,
 };
 
-export default function CosmosSendRowsCustom({ account, transaction }: Props) {
+export default function OsmosisSendRowsCustom({ account, transaction }: Props) {
   const navigation = useNavigation();
   const editMemo = useCallback(() => {
     navigation.navigate(ScreenName.CosmosFamilyEditMemo, {


### PR DESCRIPTION
Adds edit memo field as done in Cosmos. Refactors Cosmos code to be able to re-use the same component. Tested to be working for both Cosmos and Osmosis.

Video was too large for github so attaching screenshots:
<img width="523" alt="Screen Shot 2022-08-10 at 7 59 36 PM" src="https://user-images.githubusercontent.com/98154129/183985104-7e16b104-4cd5-4166-8506-c705ff196c97.png">
<img width="527" alt="Screen Shot 2022-08-10 at 7 59 43 PM" src="https://user-images.githubusercontent.com/98154129/183985100-01ef8188-1b7d-4728-9b1a-85e2bf23e6c4.png">
<img width="530" alt="Screen Shot 2022-08-10 at 7 59 51 PM" src="https://user-images.githubusercontent.com/98154129/183985099-e8bb0773-e10a-4c0a-b776-8a441860d47d.png">
<img width="526" alt="Screen Shot 2022-08-10 at 7 59 59 PM" src="https://user-images.githubusercontent.com/98154129/183985095-b93b2e6c-5497-4c38-9b93-29af4a6d032d.png">
<img width="515" alt="Screen Shot 2022-08-10 at 8 00 23 PM" src="https://user-images.githubusercontent.com/98154129/183985085-159a7254-06dd-4f20-919e-8e86ca405e9a.png">

